### PR TITLE
Decreased memory usage greatly.

### DIFF
--- a/Breakout/Source/Actor.cpp
+++ b/Breakout/Source/Actor.cpp
@@ -10,13 +10,11 @@ Actor::Actor() {
 Actor::~Actor() {
 }
 
-void Actor::Create(sf::Texture& texture, const sf::Vector2f& size, const sf::Vector2f& position) {
+void Actor::Create(const sf::Vector2f& size, const sf::Vector2f& position) {
 	mSize = size;
 	mPosition = position;
 	mShape.setSize(mSize);
 	mShape.setPosition(mPosition);
-	mTexture = texture;
-	mShape.setTexture(&texture);
 }
 
 void Actor::Draw(sf::RenderWindow& window) const {

--- a/Breakout/Source/Ball.cpp
+++ b/Breakout/Source/Ball.cpp
@@ -9,6 +9,12 @@ Ball::Ball() {
 	mPreviousPosition = { 0.0f, 0.0f };
 }
 
+void Ball::SetTexture(const sf::Texture texture) {
+	// Not a reference because the texture object needs to live while the ball lives
+	mTexture = texture;
+	mShape.setTexture(&mTexture);
+}
+
 void Ball::UpdatePosition(const sf::RenderWindow& window, const float dt) {
 	mPreviousPosition = mPosition;
 	mPosition += mVelocity*dt;

--- a/Breakout/Source/Brick.cpp
+++ b/Breakout/Source/Brick.cpp
@@ -2,19 +2,14 @@
 
 void Brick::SetAttributes(const tinyxml2::XMLElement* brickTypeElement) {
     mIdentifier = 0[const_cast<char*>(brickTypeElement->Attribute("Id"))];
-    mTexture.loadFromFile("Resource/" + std::string(brickTypeElement->Attribute("Texture")));
     
     // Impenetrable bricks have different attributes
     if (mIdentifier == 'I') {
         mHitPoints = -1; // will automatically cast to a huge number
-        mBreakScore = 0;
     }
     else {
         mHitPoints = strtod(brickTypeElement->Attribute("HitPoints"), NULL);
-        mBreakScore = strtod(brickTypeElement->Attribute("BreakScore"), NULL);
     }
-
-    mShape.setTexture(&mTexture);
 }
 
 BrickType Brick::GetBrickType() const {

--- a/Breakout/Source/Include/Actor.h
+++ b/Breakout/Source/Include/Actor.h
@@ -7,12 +7,11 @@ class Actor {
 public:
 	Actor();
 	~Actor();
-	void Create(sf::Texture& texture, const sf::Vector2f& size, const sf::Vector2f& position);
+	void Create(const sf::Vector2f& size, const sf::Vector2f& position);
 	void Draw(sf::RenderWindow& window) const;
 	
 protected:
 	sf::Vector2f mSize;
 	sf::Vector2f mPosition;
 	sf::RectangleShape mShape;
-	sf::Texture mTexture;
 };

--- a/Breakout/Source/Include/Ball.h
+++ b/Breakout/Source/Include/Ball.h
@@ -6,6 +6,7 @@ class Ball : public Entity {
 public:
 	Ball();
 	
+	void SetTexture(const sf::Texture texture);
 	void UpdatePosition(const sf::RenderWindow& window, const float dt);
 	void NormalizeVelocity();
 	void ResetVelocity();
@@ -15,5 +16,5 @@ public:
 	inline void RewindPosition() { mPosition = mPreviousPosition; mShape.setPosition(mPosition); }
 private:
 	sf::Vector2f mVelocity;
-	
+	sf::Texture mTexture;
 };

--- a/Breakout/Source/Include/Brick.h
+++ b/Breakout/Source/Include/Brick.h
@@ -14,19 +14,17 @@ enum BrickType { // NOT a class enum
 
 class Brick : public Entity {
 public:
-    Brick() : mIdentifier('\0'), mHitPoints(0), mBreakScore(0) {}
+    Brick() : 
+        mIdentifier('\0'), mHitPoints(0) {}
+
     void SetAttributes(const tinyxml2::XMLElement*);
     BrickType GetBrickType() const;
+    inline void SetTexture(const sf::Texture& texturePtr) { mShape.setTexture(&texturePtr); }
     inline bool IsDead() { return mHitPoints == 0 ? true : false; }
-    inline unsigned int GetBreakScore() const{ return mBreakScore; }
     inline void DecreaseHitPoints() { mHitPoints--; }
-
-    // QUESTIONABLE CHOICE
-    inline sf::Texture GetTexture() const { return mTexture; }
 
 private:
     char mIdentifier;
     unsigned int mHitPoints;
-    unsigned int mBreakScore;
 };
 

--- a/Breakout/Source/Include/Level.h
+++ b/Breakout/Source/Include/Level.h
@@ -25,11 +25,15 @@ private:
 	sf::Texture mBallTexture;
 	Ball mBall;
 
+	// Background 
+	sf::RectangleShape mBackground;
+
 	// Bricks info
 	unsigned int mRowCount;
 	unsigned int mColumnCount;
 	unsigned int mRowSpacing;
 	unsigned int mColumnSpacing;
+
 	sf::Texture mBackgoundTexture; // Didn't load this oops
 	std::array<Brick, 4> mBrick;
 	std::array<sf::Texture, 4> mBrickTexture;
@@ -37,6 +41,7 @@ private:
 	std::array<sf::SoundBuffer, 3> mBreakSoundBuffer;
 	std::array<sf::Sound, 4> mHitSound;
 	std::array<sf::Sound, 3> mBreakSound;
+	std::array<unsigned int, 4> mBrickBreakScore;
 	std::string mBrickLayout;
 
 	std::list<Brick> mBrickList;

--- a/Breakout/Source/Include/Paddle.h
+++ b/Breakout/Source/Include/Paddle.h
@@ -4,7 +4,9 @@
 
 class Paddle : public Entity {
 public:
+	void SetTexture(const sf::Texture texture);
 	void SetPosition
 	(const sf::Vector2i& position, const sf::RenderWindow& window);
 private:
+	sf::Texture mTexture;
 };

--- a/Breakout/Source/Paddle.cpp
+++ b/Breakout/Source/Paddle.cpp
@@ -1,5 +1,11 @@
 #include "Paddle.h"
 
+void Paddle::SetTexture(const sf::Texture texture) {
+	// Not a reference because the texture object needs to live while the ball lives
+	mTexture = texture;
+	mShape.setTexture(&mTexture);
+}
+
 void Paddle::SetPosition(const sf::Vector2i& position, const sf::RenderWindow& window) {
 
 	float xPosition = static_cast<float>(position.x);


### PR DESCRIPTION
The textures for the bricks are now not loaded for each brick instance, but only once per level and reused among all brick instances. This reduced the memory usage by around 20 times, approx. Also, the break score does not need to be passed to each brick individually. Each brick instance requires only a position, an intentifier, and hit points. Might reduce the memory usage even more later when I figure out where I'm losing memory.